### PR TITLE
Hi! This is a pull request that should help people trying to use teambox with google apps as email provider

### DIFF
--- a/app/models/emailer.rb
+++ b/app/models/emailer.rb
@@ -53,6 +53,7 @@ class Emailer < ActionMailer::Base
     defaults
     recipients    user.email
     from          from_user("#{project.permalink}+conversation+#{conversation.id}", conversation.comments.first.user)
+    reply_to      from_user("#{project.permalink}+conversation+#{conversation.id}", conversation.comments.first.user)
     subject       "[#{project.permalink}] #{title}"
     body          :project => project, :conversation => conversation, :recipient => user
   end
@@ -61,6 +62,7 @@ class Emailer < ActionMailer::Base
     defaults
     recipients    user.email
     from          from_user("#{project.permalink}+task+#{task.id}", task.comments.first.user)
+    reply_to      from_user("#{project.permalink}+task+#{task.id}", task.comments.first.user)
     subject       "[#{project.permalink}] #{task.name}"
     body          :project => project, :task => task, :task_list => task.task_list, :recipient => user
   end


### PR DESCRIPTION
I'm using teambox in my server, and I was using Google Apps as the email sending service. The problem I was having was that (at least my) Google Apps configuration didn't allow teambox to send emails from "custom" email addresses. For example: 

One of my projects is called project1, and emails should have been coming to my mailbox as project1+conversation+XX@mydomain.com. Google apps wasn't allowing this and emails were sent from teambox@mydomain.com, which didn't allow teambox to parse them correctly.

What I did was to simply add a reply-to field on the emails being sent, thus "forcing" people to send the email to the right address. This way, emails get parsed correctly and it's working.

This change shouldn't affect people with another email provider that works.

Cheers!

(Soy chileno, pero prefiero escribirles en inglés por si alguno de ustedes no habla español =P Saludos!).
