### PR TITLE
Codaset hooks

### DIFF
--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -27,6 +27,13 @@ class HooksController < ApplicationController
     case params[:hook_name]
     when 'github'
       @current_project.conversations.from_github JSON.parse(params[:payload])
+    when 'codaset'
+      case params[:event]
+      when 'git_push'
+        @current_project.conversations.from_codaset JSON.parse(params[:payload])
+      else
+        raise ArgumentError
+      end
     when 'email'
       Emailer.receive_params(params)
     when 'pivotal'

--- a/spec/controllers/hooks_controller_spec.rb
+++ b/spec/controllers/hooks_controller_spec.rb
@@ -246,6 +246,80 @@ describe HooksController do
       end
     end
     
+    describe "Codaset" do
+      describe "Git Push" do
+        it "posts to the project timeline" do
+          event = 'git_push'
+          payload = <<-JSON
+            {
+              "datetime": {
+                "d": "2010-10-21", 
+                "t": "20:06:00"
+              }, 
+              "project": {
+                "description": "testovaci", 
+                "id": 5822, 
+                "owner": {
+                  "id": 1976, 
+                  "login": "petrblaho", 
+                  "name": "Petr Blaho"
+                }, 
+                "slug": "testovaci", 
+                "state": "public", 
+                "title": "testovaci", 
+                "urls": {
+                  "long": "http://codaset.com/petrblaho/testovaci", 
+                  "short": "http://bit.ly/ceOHZ0"
+                }
+              }, 
+              "push": {
+                "branch": "master", 
+                "commit_count": 1, 
+                "commits": [
+                  {
+                    "commit_time": "2010-10-21 20:07:37", 
+                    "identifier": "f341364f52670c5a9b5c36fdb7a80e2f678ab11f", 
+                    "message": "First scaffold test", 
+                    "user": {
+                      "email": "petr.blaho@gmail.com", 
+                      "id": 1976, 
+                      "login": "petrblaho"
+                    }
+                  }
+                ], 
+                "message": "master changed from c998ad6 to f341364", 
+                "urls": {
+                  "long": "http://codaset.com/petrblaho/testovaci/source/master", 
+                  "short": "http://bit.ly/980bok"
+                }
+              }, 
+              "user": {
+                "email": null, 
+                "id": 1, 
+                "login": "anonymous", 
+                "name": "an anonymous user"
+              }
+            }
+             JSON
+          
+          post :create, :payload => payload, :hook_name => 'codaset', :event => event, :project_id => @project.id
+          
+          conversation = @project.conversations.first
+          conversation.should be_simple
+          conversation.name.should be_nil
+          
+          expected = (<<-HTML).strip
+          <div class='hook_codaset'><h3>New code on <a href='http://codaset.com/petrblaho/testovaci'>testovaci</a> master</h3>
+
+petrblaho - <a href='http://codaset.com/petrblaho/testovaci/source/master/commit/f341364f52670c5a9b5c36fdb7a80e2f678ab11f'>First scaffold test</a><br>
+</div>
+          HTML
+          
+          conversation.comments.first.body.should == expected
+        end
+      end
+    end
+    
     describe "GitHub" do
       it "posts to the project timeline" do
         payload = <<-JSON


### PR DESCRIPTION
Hi,

I have implemented hook for codaset.com git push event.

It practicaly copies github hook behavior with minor changes.

Codaset has more types of events including tickets and milestones workflow, wiki and blog posts changes and git branching and tagging.

I will try to implement more codaset events hooks to teambox in future as I am using both codaset and teambox myself.

All comments and ideas are welcome.

With regards,
Petr Blaho
