### PR TITLE
GitHub and PivotalTracker integration small improvements

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -27,13 +27,13 @@ class Conversation < RoleRecord
     text = description_for_github_push(payload)
     
     self.create!(:body => "<div class='hook_github'>#{text}</div>", :simple => true) do |conversation|
-      conversation.user = conversation.project.user if conversation.project
+      conversation.user = conversation.project.users.detect { |u| u.name == payload['commits'][0]['author']['name'] } if payload['commits'].size > 0
       yield conversation if block_given?
     end
   end
   
   def self.description_for_github_push(payload)
-    text = "<h3>New code on <a href='%s'>%s</a> %s</h3>\n\n" % [
+    text = "<b>New code on <a href='%s'>%s</a> %s</b>\n\n" % [
       payload['repository']['url'], payload['repository']['name'], payload['ref']
     ]
     

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -134,7 +134,7 @@ class Task < RoleRecord
 
     comment = case activity[:event_type]
     when 'story_create'
-      "#{story[:description]}\n\n<a href='#{story[:url]}'>View on #PT</a>"
+      "#{story[:description]}\n\n<a href=http://www.pivotaltracker.com/story/show/#{story[:id]}>View on #PT</a>"
     when 'story_update'
       if story[:current_state]
         # TODO: setting assigned person all the time might not be what we want


### PR DESCRIPTION
In reply to a support e-mail discussion, here are our issues while beta testing integrations that we want to address:
1. Set the GitHub conversation author based on the commit author by matching the name or email like you do for Pivotal, not as the Teambox project owner as it is the case today. This is very important so we can track activity by user.
2. The "New code on..." message has a very large font and looks odd. I think just to bold it should be enough to make it stand out.
3. The "View on #PT" link to the story in Pivotal is incorrect or missing for some tasks.

Please review and deploy the changes if everything is ok.
