### PR TITLE
fix sql syntax for postgresql

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -100,7 +100,7 @@ class Conversation < RoleRecord
   end
 
   define_index do
-    where "`conversations`.`deleted` = 0"
+    where '"conversations"."deleted" = FALSE'
 
     indexes name, :sortable => true
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -176,7 +176,7 @@ class Page < RoleRecord
   end
 
   define_index do
-    where "`pages`.`deleted` = 0"
+    where '"pages"."deleted" = FALSE'
 
     indexes name, :sortable => true
     indexes description

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -201,7 +201,7 @@ class Task < RoleRecord
   end
 
   define_index do
-    where "`tasks`.`deleted` = 0"
+    where '"tasks"."deleted" = FALSE'
 
     indexes name, :sortable => true
 

--- a/app/models/task_list.rb
+++ b/app/models/task_list.rb
@@ -45,7 +45,7 @@ class TaskList < RoleRecord
   end
 
   define_index do
-    where "`task_lists`.`deleted` = 0"
+    where '"task_lists"."deleted" = FALSE'
 
     indexes name, :sortable => true
     has project_id, created_at, updated_at


### PR DESCRIPTION
This commit makes 

```
bundle exec rake ts:index RAILS_ENV=production
```

and the rest of the sphinx magic work for me with postgresql.
