### PR TITLE
Teambox3.2

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -82,7 +82,7 @@ class Person < ActiveRecord::Base
       INNER JOIN projects ON projects.id = people.project_id
       INNER JOIN users ON users.id = people.user_id
       WHERE people.project_id IN (#{project_ids.join(',')})
-        AND (people.deleted IS NULL OR people.deleted IS FALSE)
+        AND (people.deleted IS NULL OR people.deleted = #{connection.quoted_false})
       ORDER BY users.id = #{current_user.try(:id).to_i} DESC, users.first_name, users.last_name
     SQL
   end


### PR DESCRIPTION
let the database adapter quote the false in the select rows statement within user_names_from_projects. This was causing sqlite to break because it doesn't understand IS FALSE. = 0 or = 'f' etc will now be presented by the database adapter. I've run through Arel and this seems to be how it's handled internally.

Can someone please check this works on their MySQL db and pull if it's ok? I don't have MySQL set up, if necessary I'll install if but if someone has a second just try it out and make sure it works :-)
