### PR TITLE
2011 05 07 teambox 3.2 postgresql migration fix

### DIFF
--- a/db/migrate/20110228182657_reinforcewatcheruniqueness.rb
+++ b/db/migrate/20110228182657_reinforcewatcheruniqueness.rb
@@ -5,13 +5,12 @@ class Reinforcewatcheruniqueness < ActiveRecord::Migration
     end
 
     Watcher.connection.execute <<-EOF
-      DELETE #{Watcher.table_name}
-      FROM #{Watcher.table_name},
-        (SELECT MAX(id) as dupid, COUNT(id) as dupcnt, user_id, watchable_id, watchable_type
+      DELETE 
+      FROM #{Watcher.table_name} WHERE id IN
+        (SELECT MAX(id) as id
          FROM #{Watcher.table_name}
          GROUP BY user_id, watchable_id, watchable_type
-         HAVING dupcnt > 1) as duplicates
-      WHERE #{Watcher.table_name}.id = duplicates.dupid
+         HAVING COUNT(id) > 1) 
     EOF
 
     unless index_exists?(:watchers, [:user_id, :watchable_id, :watchable_type], :name => 'watchers_uniqueness_index', :unique => true)


### PR DESCRIPTION
I tried migrating my postgresql database to the teambox3.2 branch and encountered a postgresql syntax problem that I was able to circumvent with the attached commit.
I think that is does the same as the original code and the syntax is correct for postgresql.

So this is more a hint that this migration script will probably not work on other databases than mysql unless it is changed.
