### PR TITLE
Isolate test code

### DIFF
--- a/lib/tasks/rcov.rake
+++ b/lib/tasks/rcov.rake
@@ -1,24 +1,32 @@
-require 'cucumber/rake/task'
-require 'rspec/core/rake_task'
+begin
+  require 'cucumber/rake/task'
+  require 'rspec/core/rake_task'
 
-namespace :rcov do
-  Cucumber::Rake::Task.new(:cucumber_run) do |t|
-    t.rcov = true
-    t.rcov_opts = %w{--rails --exclude osx\/objc,gems\/,spec\/,features\/ --aggregate coverage.data}
-    t.rcov_opts << %[-o "coverage"]
+  namespace :rcov do
+    Cucumber::Rake::Task.new(:cucumber_run) do |t|
+      t.rcov = true
+      t.rcov_opts = %w{--rails --exclude osx\/objc,gems\/,spec\/,features\/ --aggregate coverage.data}
+      t.rcov_opts << %[-o "coverage"]
+    end
+
+    RSpec::Core::RakeTask.new(:rspec_run) do |t|
+      t.pattern = 'spec/**/*_spec.rb'
+      t.rcov = true
+      t.rcov_opts = %w{--rails --exclude osx\/objc,gems\/,spec\/,features\/ --aggregate coverage.data}
+      t.rcov_opts << %[-o "coverage"]
+    end
+
+    desc "Run both specs and features to generate aggregated coverage"
+    task :all do |t|
+      rm "coverage.data" if File.exist?("coverage.data")
+      Rake::Task["rcov:cucumber_run"].invoke
+      Rake::Task["rcov:rspec_run"].invoke
+    end
   end
 
-  RSpec::Core::RakeTask.new(:rspec_run) do |t|
-    t.pattern = 'spec/**/*_spec.rb'
-    t.rcov = true
-    t.rcov_opts = %w{--rails --exclude osx\/objc,gems\/,spec\/,features\/ --aggregate coverage.data}
-    t.rcov_opts << %[-o "coverage"]
-  end
-
-  desc "Run both specs and features to generate aggregated coverage"
-  task :all do |t|
-    rm "coverage.data" if File.exist?("coverage.data")
-    Rake::Task["rcov:cucumber_run"].invoke
-    Rake::Task["rcov:rspec_run"].invoke
+rescue LoadError
+  desc 'RCov rake tasks not available (Cucumber or RSpec not installed)'
+  task :rcov do
+    abort 'RCov tasks are not available. Make sure Cucumber and RSpec are installed.'
   end
 end

--- a/vendor/plugins/rspec-on-rails-matchers/init.rb
+++ b/vendor/plugins/rspec-on-rails-matchers/init.rb
@@ -1,6 +1,8 @@
-# We are only loading the modules we are using right now
-# require 'spec/rails/matchers/observers'
-require 'rspec/rails/matchers/associations'
-require 'rspec/rails/matchers/validations'
-# require 'spec/rails/matchers/views'
-# require 'spec/rails/matchers/observers'
+if Rails.env == "test"
+  # We are only loading the modules we are using right now
+  # require 'spec/rails/matchers/observers'
+  require 'rspec/rails/matchers/associations'
+  require 'rspec/rails/matchers/validations'
+  # require 'spec/rails/matchers/views'
+  # require 'spec/rails/matchers/observers'
+end


### PR DESCRIPTION
Hi folks, these are a few fixes for some test code that was being run in the production environment (rcov task and rspec-on-rails-matchers). If you bundle installed without the "test" and "testing" groups, this would cause rake commands to fail.
