### PR TITLE
Fixes for receive_email pipe script and Whenever

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'activesupport-i18n-patch', :git => 'git://github.com/teambox/activesupport-
 
 gem 'nokogiri'
 gem 'SystemTimer', '~> 1.2.0', :require => 'system_timer'
-gem 'whenever', '~> 0.4.1', :require => nil
+gem 'whenever', '~> 0.7.0', :require => nil
 gem 'icalendar', '~> 1.1.3'
 gem 'libxml-ruby', '1.1.3', :require => 'libxml'
 gem 'rdiscount', '~> 1.6.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     cgi_multipart_eof_fix (2.5.0)
     childprocess (0.2.2)
       ffi (~> 1.0.6)
-    chronic (0.3.0)
+    chronic (0.6.4)
     closure-compiler (0.3.3)
     coffee-script (2.1.1)
       coffee-script-source
@@ -250,8 +250,9 @@ GEM
       nokogiri (>= 1.2.0)
       rack (>= 1.0)
       rack-test (>= 0.5.3)
-    whenever (0.4.2)
-      chronic (>= 0.2.3)
+    whenever (0.7.0)
+      activesupport (>= 2.3.4)
+      chronic (~> 0.6.3)
     xml-simple (1.0.12)
     xpath (0.1.2)
       nokogiri (~> 1.3)
@@ -311,5 +312,5 @@ DEPENDENCIES
   tzinfo (~> 0.3.12)
   vestal_versions (~> 1.2.2)!
   webrat
-  whenever (~> 0.4.1)
+  whenever (~> 0.7.0)
   will_paginate!

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,4 +1,9 @@
-set :output, "#{Rails.root}/log/cron.log"
+# When running Whenever, the environment should be specified with --set environment
+ENV['RAILS_ENV'] = environment || 'production'
+
+require File.join(File.dirname(__FILE__), "environment")
+
+set :output, File.join(Rails.root, "log", "cron.log")
 
 every 1.hour do
   rake "mail:reminders", :environment => :production

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -16,5 +16,5 @@ if Teambox.config.allow_incoming_email and Teambox.config.incoming_email_setting
 end
 
 every 30.minutes do
-  rake "ts:rebuild", :environment => :production
+  rake "ts:reindex", :environment => :production
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,8 +9,10 @@ every 1.hour do
   rake "mail:reminders", :environment => :production
 end
 
-every 1.minutes do
-  rake "mail:inbox", :environment => :production
+if Teambox.config.allow_incoming_email and Teambox.config.incoming_email_settings[:type].downcase != 'pipe'
+  every 1.minutes do
+    rake "mail:inbox", :environment => :production
+  end
 end
 
 every 30.minutes do

--- a/config/teambox.yml
+++ b/config/teambox.yml
@@ -85,6 +85,7 @@ defaults: &defaults
   # * Run `rake mail:inbox` periodically from cron to process incoming emails.
   # Important: Email should be received in the same domain it's being sent from.
   incoming_email_settings:
+    # Set this to "pipe" if piping the mail directly to the receive_mail script
     :type:      POP
     :address:   mail.example.com
     :user_name: USER

--- a/script/receive_email
+++ b/script/receive_email
@@ -1,15 +1,19 @@
 #!/usr/bin/env ruby
 # This script can be used to process an incoming e-mail, e.g. by configuring Postfix to pipe it here
 
-ENV['RAILS_ENV'] = ENV['RAILS_ENV'] || 'production'
-log_file = File.dirname(__FILE__) + '/../log/' + ENV['RAILS_ENV'] + '.log'
+Dir.chdir File.join(File.dirname(__FILE__), '..') do
 
-# Send output to the log so we don't generate a bounce message
-$stderr.reopen(log_file, 'a')
-$stderr.sync = true
-$stdout.reopen(log_file, 'a')
-$stderr.sync = true
+  ENV['RAILS_ENV'] = ENV['RAILS_ENV'] || 'production'
+  log_file = File.dirname(__FILE__) + '/../log/' + ENV['RAILS_ENV'] + '.log'
 
-require File.dirname(__FILE__) + '/../config/environment'
+  # Send output to the log so we don't generate a bounce message
+  $stderr.reopen(log_file, 'a')
+  $stderr.sync = true
+  $stdout.reopen(log_file, 'a')
+  $stderr.sync = true
 
-Emailer.receive(STDIN.read)
+  require File.dirname(__FILE__) + '/../config/environment'
+
+  Emailer.receive(STDIN.read)
+
+end

--- a/script/receive_email
+++ b/script/receive_email
@@ -10,7 +10,7 @@ Dir.chdir File.join(File.dirname(__FILE__), '..') do
   $stderr.reopen(log_file, 'a')
   $stderr.sync = true
   $stdout.reopen(log_file, 'a')
-  $stderr.sync = true
+  $stdout.sync = true
 
   require File.dirname(__FILE__) + '/../config/environment'
 


### PR DESCRIPTION
These commits fix the following:
- receive_email script breakage if not specifically run from the Rails root
- typo in output redirection in receive_email script which could inadvertently generate a bounce message
- old version of Whenever doesn't work with Bundler
- Whenever config is broken (tries to call a Rails method)
- extraneous cron job for mail:inbox will fail if using pipe method
- Sphinx cron job incorrectly rebuilds rather than reindexing
