### PR TITLE
Fix broken processing of incoming email attachments

### DIFF
--- a/app/models/emailer/incoming.rb
+++ b/app/models/emailer/incoming.rb
@@ -221,7 +221,17 @@ module Emailer::Incoming
     @body    = strip_responses(@body).strip_tags.to_s.strip
     @subject = email.subject.to_s.gsub(REPLY_REGEX, "").strip
     @files   = email.attachments || []
-    
+
+    # Format attachments for processing by Paperclip
+    @files.collect! do |attachment|
+      file = StringIO.new(attachment.decoded)
+      file.class.class_eval { attr_accessor :original_filename, :content_type }
+      file.original_filename = attachment.filename
+      file.content_type = attachment.mime_type
+
+      file
+    end
+
     Rails.logger.info "#{@user.name} <#{@user.email}> sent '#{@subject}' to #{@to}"
   end
   


### PR DESCRIPTION
Incoming e-mail processing for e-mails with attachments is broken because Paperclip expects an object that implements rewind, which the mail part objects do not. They also do not have some attributes Paperclip requires.

This commit fixes these issues.
