### PR TITLE
Adds SSH authentication when fetching incoming emails with POP.

### DIFF
--- a/app/models/emailer/incoming.rb
+++ b/app/models/emailer/incoming.rb
@@ -36,6 +36,9 @@ module Emailer::Incoming
   end
 
   def self.fetch_pop(settings)
+    if Teambox.config.enable_pop_ssh 
+      Net::POP3.enable_ssl(OpenSSL::SSL::VERIFY_NONE)
+    end
     Net::POP3.start(settings[:address], settings[:port], settings[:user_name], settings[:password]) do |pop|
       pop.mails.each do |email|
         begin

--- a/config/teambox.yml
+++ b/config/teambox.yml
@@ -87,9 +87,13 @@ defaults: &defaults
   incoming_email_settings:
     :type:      POP
     :address:   mail.example.com
+    :port:      110
     :user_name: USER
     :password:  PASSWORD
 
+  # Set to true when using Gmail
+  enable_pop_ssh: false
+  
   # Allow teambox.com to gather statistics about this installation
   tracking_enabled: true
 


### PR DESCRIPTION
When fetching emails from Gmail's POP server, you need to set Net::POP3.enable_ssl(OpenSSL::SSL::VERIFY_NONE)
before Net::POP3.start

I added a config setting to enable this in teambox.yml
