### PR TITLE
Changes trimmer initializer should_cache method to check for Heroku

### DIFF
--- a/config/initializers/trimmer.rb
+++ b/config/initializers/trimmer.rb
@@ -14,7 +14,7 @@ trimmer_static_cache_block = Proc.new do |env,res|
     else
       false
     end
-    should_cache = false unless Teambox::Application.config.action_controller.perform_caching
+    should_cache = false unless Teambox::Application.config.action_controller.perform_caching && !Teambox.config.heroku?
     should_cache
 end 
 


### PR DESCRIPTION
Since the Heroku filesystem is read-only, trimmer should not try to
write to a cache.
