### PR TITLE
Hide people's data exports

### DIFF
--- a/app/controllers/teambox_datas_controller.rb
+++ b/app/controllers/teambox_datas_controller.rb
@@ -13,6 +13,8 @@ class TeamboxDatasController < ApplicationController
   end
   
   def show
+    head(:forbidden) and return unless @data.downloadable?(current_user)
+
     respond_to do |f|
       if @data.type_name == :import and @data.need_data? and @data.data == nil
         @data.status_name = :uploading


### PR DESCRIPTION
Without this patch, you can see other people's data exports, e.g : https://teambox.com/datas/2336
