### PR TITLE
fix time tracking, calendar current time zone bug

### DIFF
--- a/app/helpers/calendars_helper.rb
+++ b/app/helpers/calendars_helper.rb
@@ -64,7 +64,7 @@ module CalendarsHelper
 
       cell_text = "<div class=\"cd\">#{cur.mday}</div>"
       cell_attrs = {}
-      cell_attrs[:class] = "day this_month cal_wd#{cur.wday} #{'today' if (cur == Time.current.to_date)} "
+      cell_attrs[:class] = "day this_month cal_wd#{cur.wday} #{'today' if (cur == Time.current.in_time_zone(current_user.time_zone).to_date)} "
       cell_attrs[:id] = "day_#{cur.month}_#{cur.mday}"
 
       #if markable?(calendar,marked,year,month,cell_text)


### PR DESCRIPTION
For instance, I have seted my time zone to Adelaide(9:30), if I go to the calendar at 9:00AM morning the current day is 8th Feb but in the Time tracking section, it shows today is 7th Feb. This because 9AM in Adelaide is around 5PM in San Francisco, which happens to be one day different.
